### PR TITLE
Address nested slot issues (light DOM)

### DIFF
--- a/index.js
+++ b/index.js
@@ -175,16 +175,16 @@ export default function(opts) {
 
 			// Look for named slots below this element. IMPORTANT: This may return slots nested deeper (see check in forEach below).
 			const queryNamedSlots = this.querySelectorAll('[slot]');
-			queryNamedSlots.forEach(candidate => {
+			for(let candidate of queryNamedSlots) {
 				// Traverse parents and find first custom element and ensure its tag name matches this one. That way, we
 				// can ensure we aren't inadvertently getting nested slots that apply to other custom elements.
 				let slotParent = this.findSlotParent(candidate);
-				if (slotParent === null) return;
-				if (slotParent.tagName !== this.tagName) return;
+				if (slotParent === null) continue;
+				if (slotParent.tagName !== this.tagName) continue;
 
 				slots[candidate.slot] = candidate;
 				this.removeChild(candidate);
-			});
+			}
 
 			// Default slots are indeed allowed alongside named slots, as long as the named slots are elided *first*. We
 			// should also make sure we trim out whitespace in case all slots and elements are already removed. We don't want
@@ -257,7 +257,7 @@ export default function(opts) {
 		 * @param {string} newValue
 		 */
 		attributeChangedCallback(name, oldValue, newValue) {
-			this.debug('attributes changed', {name, oldValue, newValue});
+			this.debug('attributes changed', { name, oldValue, newValue });
 
 			if (this.elem && newValue !== oldValue) {
 				this.elem.$set({ [name]: newValue });

--- a/index.js
+++ b/index.js
@@ -156,7 +156,7 @@ export default function(opts) {
 		}
 
 		/**
-		 * Traverses DOM to find the first custom element that the provided slot belongs to.
+		 * Traverses DOM to find the first custom element that the provided <slot> element happens to belong to.
 		 *
 		 * @param {Element} slot
 		 * @returns {HTMLElement|null}
@@ -170,17 +170,26 @@ export default function(opts) {
 			return null;
 		}
 
+		/**
+		 * Indicates if the provided <slot> element instance belongs to this custom element or not.
+		 *
+		 * @param {Element} slot
+		 * @returns {boolean}
+		 */
+		isOwnSlot(slot) {
+			let slotParent = this.findSlotParent(slot);
+			if (slotParent === null) return false;
+			return (slotParent === this);
+		}
+
 		getSlots() {
 			let slots = {};
 
 			// Look for named slots below this element. IMPORTANT: This may return slots nested deeper (see check in forEach below).
 			const queryNamedSlots = this.querySelectorAll('[slot]');
 			for(let candidate of queryNamedSlots) {
-				// Traverse parents and find first custom element and ensure its tag name matches this one. That way, we
-				// can ensure we aren't inadvertently getting nested slots that apply to other custom elements.
-				let slotParent = this.findSlotParent(candidate);
-				if (slotParent === null) continue;
-				if (slotParent !== this) continue;
+				// Skip this slot if it doesn't happen to belong to THIS custom element.
+				if (!this.isOwnSlot(candidate)) continue;
 
 				slots[candidate.slot] = candidate;
 				// TODO: Potentially problematic in edge cases where the browser may *oddly* return slots from query selector

--- a/index.js
+++ b/index.js
@@ -217,9 +217,17 @@ export default function(opts) {
 			for(let mutation of mutations) {
 				if (mutation.type === 'childList') {
 					let slots = this.getShadowSlots();
+
+					// TODO: Should it re-render if the count changes at all? e.g. what if slots were REMOVED (reducing it to zero)?
+					//  We'd have latent content left over that's not getting updated, then. Consider rewrite...
 					if (Object.keys(slots).length) {
+
 						props.$$slots = createSvelteSlots(slots);
+
+						// TODO: Why is this set here but not re-rendered unless the slot count changes?
+						// TODO: Also, why is props.$$slots set above but not just passed here? Calling createSvelteSlots(slots) 2x...
 						this.elem.$set({ '$$slots': createSvelteSlots(slots) });
+
 						// do full re-render on slot count change - needed for tabs component
 						if (this.slotCount !== Object.keys(slots).length) {
 							Array.from(this.attributes).forEach(attr => props[attr.name] = attr.value); // TODO: Redundant, repeated on connectedCallback().

--- a/index.js
+++ b/index.js
@@ -180,9 +180,14 @@ export default function(opts) {
 				// can ensure we aren't inadvertently getting nested slots that apply to other custom elements.
 				let slotParent = this.findSlotParent(candidate);
 				if (slotParent === null) continue;
-				if (slotParent.tagName !== this.tagName) continue;
+				if (slotParent !== this) continue;
 
 				slots[candidate.slot] = candidate;
+				// TODO: Potentially problematic in edge cases where the browser may *oddly* return slots from query selector
+				//  above, yet their not actually a child of the current element. This seems to only happen if another
+				//  constructor() + connectedCallback() are BOTH called for this particular element again BEFORE a
+				//  disconnectedCallback() gets called (out of sync). Only experienced in Chrome when manually editing the HTML
+				//  when there were multiple other custom elements present inside the slot of another element (very edge case?)
 				this.removeChild(candidate);
 			}
 

--- a/tests/TestTag.test.js
+++ b/tests/TestTag.test.js
@@ -47,6 +47,8 @@ describe('Component Wrapper shadow false', () => {
 		expect(el.innerHTML).toBe('<test-tag><h1>Main H1</h1> <div class="content">BOOM! <div><div slot="inner">HERE</div></div></div><!--<TestTag>--></test-tag>');
 	});
 
+	// TODO: Unit test to validate that an error occurs when they define a "default" named slot but have remaining unslotted elements left over.
+
 	it('nested tags', () => {
 		el = document.createElement('div');
 		el.innerHTML = '<test-tag><h2>Nested</h2><div slot="inner">HERE</div></test-tag>';
@@ -103,6 +105,7 @@ describe('Component Wrapper shadow true', () => {
 		el.innerHTML = '<test-shad>BOOM!<div slot="inner">HERE</div></test-shad>';
 		document.body.appendChild(el);
 		let shadowhtml = el.querySelector('test-shad').shadowRoot.innerHTML;
+		// TODO: Why does this not produce the inner HERE? Maybe just my ignorance.
 		expect(shadowhtml).toBe('<div><h1>Main H1</h1> <div class="content"><slot></slot> <div><slot name="inner"></slot></div></div><!--<TestTag>--></div>');
 	});
 

--- a/tests/TestTag.test.js
+++ b/tests/TestTag.test.js
@@ -49,12 +49,16 @@ describe('Component Wrapper shadow false', () => {
 
 	// TODO: Unit test to validate that an error occurs when they define a "default" named slot but have remaining unslotted elements left over.
 
-	it('nested tags', () => {
+	it('inner slot and default slot with other tags', () => {
 		el = document.createElement('div');
 		el.innerHTML = '<test-tag><h2>Nested</h2><div slot="inner">HERE</div></test-tag>';
 		document.body.appendChild(el);
 		expect(el.innerHTML).toBe('<test-tag><h1>Main H1</h1> <div class="content"><h2>Nested</h2> <div><div slot="inner">HERE</div></div></div><!--<TestTag>--></test-tag>');
 	});
+
+	// TODO: Validate that nested slots are working as expected (totally different tags/components)
+
+	// TODO: Validate that nested slots are working as expected (same tag)
 
 	it('Unknown slot gets ignored', () => {
 		let tmp = console.warn;

--- a/tests/light-dom.test.js
+++ b/tests/light-dom.test.js
@@ -46,7 +46,24 @@ describe('Component Wrapper shadow false', () => {
 		expect(el.innerHTML).toBe('<test-tag><h1>Main H1</h1> <div class="content">BOOM! <div><div slot="inner">HERE</div></div></div><!--<TestTag>--></test-tag>');
 	});
 
-	// TODO: Unit test to validate that an error occurs when they define a "default" named slot but have remaining unslotted elements left over.
+	// Unit test to validate that an error occurs when they define a "default" named slot but have remaining unslotted elements left over.
+	test('error when named default conflicts with extra remaining content', () => {
+		// Capture errors and ensure only the expected ones appear below.
+		let tmp = console.error;
+		let errors = [];
+		console.error = function(message) {
+			errors.push(message);
+		};
+
+		el = document.createElement('div');
+		el.innerHTML = '<test-tag>Remaining content<div slot="default">Default already set</div></test-tag>';
+		document.body.appendChild(el);
+		expect(el.innerHTML).toBe('<test-tag><h1>Main H1</h1> <div class="content"><div slot="default">Default already set</div> <div>Inner Default</div></div><!--<TestTag>--></test-tag>');
+		expect(errors).toStrictEqual(['svelteRetag: \'TEST-TAG\': Found elements without slot attribute when using slot="default"']);
+
+		// Revert
+		console.error = tmp;
+	});
 
 	test('inner slot and default slot with other tags', () => {
 		el = document.createElement('div');

--- a/tests/light-dom.test.js
+++ b/tests/light-dom.test.js
@@ -1,0 +1,72 @@
+import { describe, beforeAll, afterEach, test, expect } from 'vitest';
+import TestTag from './TestTag.svelte';
+import svelteRetag from '../index.js';
+
+// See vite.config.js for configuration details.
+
+// TODO: Needs unit tests to validate attributes/props being handled correctly (at minimum pass through)
+
+let el = null;
+
+describe('Component Wrapper shadow false', () => {
+
+	beforeAll(() => {
+		svelteRetag({ component: TestTag, tagname: 'test-tag', shadow: false });
+	});
+
+	afterEach(() => {
+		el.remove();
+	});
+
+	test('without slots', async () => {
+		el = document.createElement('div');
+		el.innerHTML = '<test-tag></test-tag>';
+		document.body.appendChild(el);
+		expect(el.innerHTML).toBe('<test-tag><h1>Main H1</h1> <div class="content">Main Default <div>Inner Default</div></div><!--<TestTag>--></test-tag>');
+	});
+
+	test('with just default slot', () => {
+		el = document.createElement('div');
+		el.innerHTML = '<test-tag>BOOM!</test-tag>';
+		document.body.appendChild(el);
+		expect(el.innerHTML).toBe('<test-tag><h1>Main H1</h1> <div class="content">BOOM! <div>Inner Default</div></div><!--<TestTag>--></test-tag>');
+	});
+
+	test('with just inner slot', () => {
+		el = document.createElement('div');
+		el.innerHTML = '<test-tag><div slot="inner">HERE</div></test-tag>';
+		document.body.appendChild(el);
+		expect(el.innerHTML).toBe('<test-tag><h1>Main H1</h1> <div class="content">Main Default <div><div slot="inner">HERE</div></div></div><!--<TestTag>--></test-tag>');
+	});
+
+	test('both slots', () => {
+		el = document.createElement('div');
+		el.innerHTML = '<test-tag>BOOM!<div slot="inner">HERE</div></test-tag>';
+		document.body.appendChild(el);
+		expect(el.innerHTML).toBe('<test-tag><h1>Main H1</h1> <div class="content">BOOM! <div><div slot="inner">HERE</div></div></div><!--<TestTag>--></test-tag>');
+	});
+
+	// TODO: Unit test to validate that an error occurs when they define a "default" named slot but have remaining unslotted elements left over.
+
+	test('inner slot and default slot with other tags', () => {
+		el = document.createElement('div');
+		el.innerHTML = '<test-tag><h2>Nested</h2><div slot="inner">HERE</div></test-tag>';
+		document.body.appendChild(el);
+		expect(el.innerHTML).toBe('<test-tag><h1>Main H1</h1> <div class="content"><h2>Nested</h2> <div><div slot="inner">HERE</div></div></div><!--<TestTag>--></test-tag>');
+	});
+
+	// TODO: Validate that nested slots are working as expected (totally different tags/components)
+
+	// TODO: Validate that nested slots are working as expected (same tag)
+
+	test('Unknown slot gets ignored', () => {
+		let tmp = console.warn;
+		console.warn = function() {
+		};
+		el = document.createElement('div');
+		el.innerHTML = '<test-tag><div slot="unknown">HERE</div></test-tag>';
+		document.body.appendChild(el);
+		expect(el.innerHTML).toBe('<test-tag><h1>Main H1</h1> <div class="content">Main Default <div>Inner Default</div></div><!--<TestTag>--></test-tag>');
+		console.warn = tmp;
+	});
+});

--- a/tests/shadow-dom.test.js
+++ b/tests/shadow-dom.test.js
@@ -1,7 +1,7 @@
-import { describe, beforeAll, afterEach, it, expect } from 'vitest';
-import { tick } from 'svelte';
-import TestTag from './TestTag.svelte';
+import { beforeAll, describe, expect, test } from 'vitest';
 import svelteRetag from '../index.js';
+import TestTag from './TestTag.svelte';
+import { tick } from 'svelte';
 
 // See vite.config.js for configuration details.
 
@@ -9,77 +9,13 @@ import svelteRetag from '../index.js';
 
 let el = null;
 
-describe('Component Wrapper shadow false', () => {
-
-	beforeAll(() => {
-		svelteRetag({ component: TestTag, tagname: 'test-tag', shadow: false });
-	});
-
-	afterEach(() => {
-		el.remove();
-	});
-
-	it('without slots', async () => {
-		el = document.createElement('div');
-		el.innerHTML = '<test-tag></test-tag>';
-		document.body.appendChild(el);
-		expect(el.innerHTML).toBe('<test-tag><h1>Main H1</h1> <div class="content">Main Default <div>Inner Default</div></div><!--<TestTag>--></test-tag>');
-	});
-
-	it('with just default slot', () => {
-		el = document.createElement('div');
-		el.innerHTML = '<test-tag>BOOM!</test-tag>';
-		document.body.appendChild(el);
-		expect(el.innerHTML).toBe('<test-tag><h1>Main H1</h1> <div class="content">BOOM! <div>Inner Default</div></div><!--<TestTag>--></test-tag>');
-	});
-
-	it('with just inner slot', () => {
-		el = document.createElement('div');
-		el.innerHTML = '<test-tag><div slot="inner">HERE</div></test-tag>';
-		document.body.appendChild(el);
-		expect(el.innerHTML).toBe('<test-tag><h1>Main H1</h1> <div class="content">Main Default <div><div slot="inner">HERE</div></div></div><!--<TestTag>--></test-tag>');
-	});
-
-	it('both slots', () => {
-		el = document.createElement('div');
-		el.innerHTML = '<test-tag>BOOM!<div slot="inner">HERE</div></test-tag>';
-		document.body.appendChild(el);
-		expect(el.innerHTML).toBe('<test-tag><h1>Main H1</h1> <div class="content">BOOM! <div><div slot="inner">HERE</div></div></div><!--<TestTag>--></test-tag>');
-	});
-
-	// TODO: Unit test to validate that an error occurs when they define a "default" named slot but have remaining unslotted elements left over.
-
-	it('inner slot and default slot with other tags', () => {
-		el = document.createElement('div');
-		el.innerHTML = '<test-tag><h2>Nested</h2><div slot="inner">HERE</div></test-tag>';
-		document.body.appendChild(el);
-		expect(el.innerHTML).toBe('<test-tag><h1>Main H1</h1> <div class="content"><h2>Nested</h2> <div><div slot="inner">HERE</div></div></div><!--<TestTag>--></test-tag>');
-	});
-
-	// TODO: Validate that nested slots are working as expected (totally different tags/components)
-
-	// TODO: Validate that nested slots are working as expected (same tag)
-
-	it('Unknown slot gets ignored', () => {
-		let tmp = console.warn;
-		console.warn = function() {
-		};
-		el = document.createElement('div');
-		el.innerHTML = '<test-tag><div slot="unknown">HERE</div></test-tag>';
-		document.body.appendChild(el);
-		expect(el.innerHTML).toBe('<test-tag><h1>Main H1</h1> <div class="content">Main Default <div>Inner Default</div></div><!--<TestTag>--></test-tag>');
-		console.warn = tmp;
-	});
-});
-
-
 describe('Component Wrapper shadow true', () => {
 
 	beforeAll(() => {
 		svelteRetag({ component: TestTag, tagname: 'test-shad', shadow: true });
 	});
 
-	it('without slots', () => {
+	test('without slots', () => {
 		el = document.createElement('div');
 		el.innerHTML = '<test-shad></test-shad>';
 		document.body.appendChild(el);
@@ -87,7 +23,7 @@ describe('Component Wrapper shadow true', () => {
 		expect(shadowhtml).toBe('<div><h1>Main H1</h1> <div class="content">Main Default <div>Inner Default</div></div><!--<TestTag>--></div>');
 	});
 
-	it('with just default slot', () => {
+	test('with just default slot', () => {
 		el = document.createElement('div');
 		el.innerHTML = '<test-shad>Boom</test-shad>';
 		document.body.appendChild(el);
@@ -96,7 +32,7 @@ describe('Component Wrapper shadow true', () => {
 		expect(el.querySelector('test-shad').innerHTML).toBe('Boom');
 	});
 
-	it('with just inner slot', () => {
+	test('with just inner slot', () => {
 		el = document.createElement('div');
 		el.innerHTML = '<test-shad><div slot="inner">HERE</div></test-shad>';
 		document.body.appendChild(el);
@@ -104,7 +40,7 @@ describe('Component Wrapper shadow true', () => {
 		expect(shadowhtml).toBe('<div><h1>Main H1</h1> <div class="content">Main Default <div><slot name="inner"></slot></div></div><!--<TestTag>--></div>');
 	});
 
-	it('both slots', () => {
+	test('both slots', () => {
 		el = document.createElement('div');
 		el.innerHTML = '<test-shad>BOOM!<div slot="inner">HERE</div></test-shad>';
 		document.body.appendChild(el);
@@ -113,7 +49,7 @@ describe('Component Wrapper shadow true', () => {
 		expect(shadowhtml).toBe('<div><h1>Main H1</h1> <div class="content"><slot></slot> <div><slot name="inner"></slot></div></div><!--<TestTag>--></div>');
 	});
 
-	it('Unknown slot gets ignored', () => {
+	test('Unknown slot gets ignored', () => {
 		let tmp = console.warn;
 		console.warn = function() {
 		};
@@ -125,7 +61,7 @@ describe('Component Wrapper shadow true', () => {
 		console.warn = tmp;
 	});
 
-	it('dynamically adding content to component', async () => {
+	test('dynamically adding content to component', async () => {
 		el = document.createElement('div');
 		el.innerHTML = '<test-shad></test-shad>';
 		document.body.appendChild(el);

--- a/tests/shadow-dom.test.js
+++ b/tests/shadow-dom.test.js
@@ -9,7 +9,7 @@ import { tick } from 'svelte';
 
 let el = null;
 
-describe('Component Wrapper shadow true', () => {
+describe('Shadow DOM', () => {
 
 	beforeAll(() => {
 		svelteRetag({ component: TestTag, tagname: 'test-shad', shadow: true });


### PR DESCRIPTION
Fix for https://github.com/crisward/svelte-tag/issues/7. Primary changes

- [x] Keep track of slots on connectedCallback() and then unwind them symmetrically on disconnectedCallback() to handle state/initialization bugs in case nested elements render from inside out
- [x] Ensure we restrict selection of slots only to the current element and not nested elements (i.e. from inverse perspective: traverse DOM up from slot and ensure nearest custom element is the current one being initialized).
- [x] Unit test to validate that only the slots that apply to the current element are selected and used during initialization
- [x] Unit test to validate that a **different** nested custom element is properly re-initialized (even though it renders first) when setup inside the default slot of another custom element