### PR TITLE
Defer render to requestAnimationFrame() to avoid unnecessary rerenders

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "svelte-retag",
-  "version": "1.0.2",
+  "version": "1.1.0-alpha.1",
   "description": "Light DOM custom element wrapper for Svelte 3 with Vite HMR support",
   "main": "index.js",
   "scripts": {

--- a/tests/Simple.iife.test.js
+++ b/tests/Simple.iife.test.js
@@ -1,4 +1,4 @@
-import { describe, beforeAll, afterEach, test, expect } from 'vitest';
+import { describe, beforeAll, beforeEach, afterEach, test, expect, vi } from 'vitest';
 import Simple from './Simple.svelte';
 import svelteRetag from '../index';
 import { setReadyState } from './test-utils.js';
@@ -13,10 +13,16 @@ describe('IIFE: Early execution tests (light DOM only)', () => {
 		svelteRetag({ component: Simple, tagname: 'simple-tag', shadow: false, debugMode });
 	});
 
+	beforeEach(() => {
+		vi.spyOn(window, 'requestAnimationFrame').mockImplementation(cb => cb());
+	});
+
 	afterEach(() => {
 		if (el) {
 			el.remove();
 		}
+
+		window.requestAnimationFrame.mockRestore();
 	});
 
 	// When render is loading: Test to validate that newly added slots affect rendered component content

--- a/tests/Simple.light-dom-whitespace.test.js
+++ b/tests/Simple.light-dom-whitespace.test.js
@@ -1,4 +1,4 @@
-import { describe, beforeAll, afterEach, test, expect } from 'vitest';
+import { describe, beforeAll, beforeEach, afterEach, test, expect, vi } from 'vitest';
 import Simple from './Simple.svelte';
 import svelteRetag from '../index';
 import { normalizeWhitespace } from './test-utils.js';
@@ -12,10 +12,16 @@ describe('<simple-tag> (Light DOM)', () => {
 		svelteRetag({ component: Simple, tagname: 'simple-tag', shadow: false, debugMode });
 	});
 
+	beforeEach(() => {
+		vi.spyOn(window, 'requestAnimationFrame').mockImplementation(cb => cb());
+	});
+
 	afterEach(() => {
 		if (el) {
 			el.remove();
 		}
+
+		window.requestAnimationFrame.mockRestore();
 	});
 
 	const unmodifiedOutput = '<simple-tag><svelte-retag>Initial 1 Initial Initial 2<!--<Simple>--></svelte-retag></simple-tag>';

--- a/tests/TestAttributes.test.js
+++ b/tests/TestAttributes.test.js
@@ -1,4 +1,4 @@
-import { describe, beforeAll, afterEach, test, expect } from 'vitest';
+import { describe, beforeAll, beforeEach, afterEach, test, expect, vi } from 'vitest';
 import TestAttributes from './TestAttributes.svelte';
 import svelteRetag from '../index';
 import { normalizeWhitespace } from './test-utils.js';
@@ -10,10 +10,16 @@ describe('Test custom element attributes', () => {
 		svelteRetag({ component: TestAttributes, tagname: 'test-attribs', shadow: false });
 	});
 
+	beforeEach(() => {
+		vi.spyOn(window, 'requestAnimationFrame').mockImplementation(cb => cb());
+	});
+
 	afterEach(() => {
 		if (el) {
 			el.remove();
 		}
+
+		window.requestAnimationFrame.mockRestore();
 	});
 
 	let allSetOutput = `

--- a/tests/TestTag.light-dom.test.js
+++ b/tests/TestTag.light-dom.test.js
@@ -1,4 +1,4 @@
-import { describe, beforeAll, afterEach, test, expect } from 'vitest';
+import { describe, beforeAll, beforeEach, afterEach, test, expect, vi } from 'vitest';
 import TestTag from './TestTag.svelte';
 import svelteRetag from '../index';
 import { normalizeWhitespace } from './test-utils.js';
@@ -15,8 +15,14 @@ describe('<test-tag> (Light DOM)', () => {
 		svelteRetag({ component: TestTag, tagname: 'test-tag', shadow: false });
 	});
 
+	beforeEach(() => {
+		vi.spyOn(window, 'requestAnimationFrame').mockImplementation(cb => cb());
+	});
+
 	afterEach(() => {
 		el.remove();
+
+		window.requestAnimationFrame.mockRestore();
 	});
 
 	test('without slots', async () => {

--- a/tests/TestTag.shadow-dom.test.js
+++ b/tests/TestTag.shadow-dom.test.js
@@ -1,4 +1,4 @@
-import { beforeAll, describe, expect, test } from 'vitest';
+import { afterEach, beforeAll, beforeEach, describe, expect, test, vi } from 'vitest';
 import svelteRetag from '../index.js';
 import TestTag from './TestTag.svelte';
 import { tick } from 'svelte';
@@ -13,6 +13,16 @@ describe('<test-tag> (Shadow DOM)', () => {
 
 	beforeAll(() => {
 		svelteRetag({ component: TestTag, tagname: 'test-shad', shadow: true });
+	});
+
+	beforeEach(() => {
+		vi.spyOn(window, 'requestAnimationFrame').mockImplementation(cb => cb());
+	});
+
+	afterEach(() => {
+		el.remove();
+
+		window.requestAnimationFrame.mockRestore();
 	});
 
 	test('without slots', () => {


### PR DESCRIPTION
Defer render to `requestAnimationFrame()` to avoid unnecessary rerenders until time to paint (particularly if already disconnected). Came up in https://github.com/sveltejs/svelte/issues/8377#issuecomment-1594002845:

> In my testing, I noticed that when running as a deferred module, it saved from pointless renders that would been eventually disconnected/reconnected anyway. However, the biggest improvements (at least on avoiding wasted rerenders) were in using iife or umd (running early prior to parsing): There were lots of disconnects but also it was able to defer "just in time" during DOM mutations so that it only renders the 1 time prior to repaint, which helped a bunch.

Tasks:

- [x] Defer Svelte component rendering to `rAF`
- [x] Fix broken unit tests which rely on synchronous rendering (i.e.: literally every single one of them)
- [ ] TODO: Consider making this optional. If so, default enabled or disabled? If so, doc in `README.md`.
- [ ] Create new unit tests to validate the new deferred rendering functionality is working properly
- [ ] Update version, bump minor ver