### PR TITLE
Fix for #15: Ensure that detection of child nodes in default slot accounts for outerHTML instead of innerHTML.

### DIFF
--- a/index.js
+++ b/index.js
@@ -299,7 +299,7 @@ export default function(opts) {
 				// 2. Deep clone doesn't work in unit tests
 				if (childNode instanceof Text) {
 					childHTML += childNode.textContent;
-				} else if (childNode.innerHTML) {
+				} else if (childNode.outerHTML) {
 					childHTML += childNode.outerHTML;
 				}
 

--- a/tests/Nesting.svelte
+++ b/tests/Nesting.svelte
@@ -1,0 +1,3 @@
+<div>
+	<slot></slot>
+</div>

--- a/tests/Nesting.test.js
+++ b/tests/Nesting.test.js
@@ -1,0 +1,36 @@
+import { describe, beforeAll, afterEach, test, expect } from 'vitest';
+import Nesting from './Nesting.svelte';
+import svelteRetag from '../index';
+import { normalizeWhitespace } from './test-utils.js';
+
+let el = null;
+let debugMode = false; // set to 'cli' to see debug output.
+
+describe('<nesting-tag> (Nesting)', () => {
+
+	beforeAll(() => {
+		svelteRetag({ component: Nesting, tagname: 'nesting-tag', shadow: false, debugMode });
+	});
+
+	afterEach(() => {
+		if (el) {
+			el.remove();
+		}
+	});
+
+	const nestedOpen = '<nesting-tag><svelte-retag><div>';
+	const nestedClose = '</div><!--<Nesting>--></svelte-retag></nesting-tag>';
+
+	test('nested (zero levels)', async () => {
+		el = document.createElement('div');
+		el.innerHTML = '<nesting-tag></nesting-tag>';
+		document.body.appendChild(el);
+		expect(normalizeWhitespace(el.innerHTML)).toBe(nestedOpen + nestedClose);
+	});
+	test('nested (one level)', async () => {
+		el = document.createElement('div');
+		el.innerHTML = '<nesting-tag><nesting-tag></nesting-tag></nesting-tag>';
+		document.body.appendChild(el);
+		expect(normalizeWhitespace(el.innerHTML)).toBe(nestedOpen + nestedOpen + nestedClose + nestedClose);
+	});
+});


### PR DESCRIPTION
Fix for #15: Ensure that detection of child nodes in default slot accounts for outerHTML` instead of `innerHTML`.