### PR TITLE
Fix for attribute state loss on first custom element after HMR

### DIFF
--- a/demo/src/lib/Counter.svelte
+++ b/demo/src/lib/Counter.svelte
@@ -7,7 +7,7 @@
 
 	import svelteLogo from '../assets/svelte.svg';
 
-	export let count;
+	export let count = 0;
 	export let award = 100;
 
 	// Since we're taking input ultimately from web components, we know it's likely to be in string form, so always cast


### PR DESCRIPTION
Fix for #21: Ensure that custom element attribute state is not lost after HMR updates and that we persist props the same way that normal HMR does when done entirely within Svelte (i.e. restore defaults after HMR only if prop is undefined).