### PR TITLE
Unit tests: Using DOM queries instead of HTML to validate tests

### DIFF
--- a/tests/Hydration.test.js
+++ b/tests/Hydration.test.js
@@ -75,6 +75,7 @@ describe('<hydration-tag>: Incorporation of special hydration attributes and tag
 
 	test('hydrate from pre-rendered HTML', async () => {
 		el = document.createElement('div');
+		// TODO: ISSUE-20: <svelte-retag> is still being used here for hydration purposes but could potentially be removed.
 		el.innerHTML = `
 			<hydration-tag data-svelte-retag-hydratable>
 				<svelte-retag>

--- a/tests/Nesting.test.js
+++ b/tests/Nesting.test.js
@@ -1,7 +1,7 @@
 import { describe, beforeAll, afterAll, afterEach, test, expect, vi } from 'vitest';
 import Nesting from './Nesting.svelte';
 import svelteRetag from '../index.js';
-import { normalizeWhitespace, syncRaf } from './test-utils.js';
+import { syncRaf } from './test-utils.js';
 
 let el = null;
 let debugMode = false; // set to 'cli' to see debug output.
@@ -24,19 +24,30 @@ describe('<nesting-tag> (Nesting)', () => {
 		window.requestAnimationFrame.mockRestore();
 	});
 
-	const nestedOpen = '<nesting-tag><svelte-retag><div>';
-	const nestedClose = '</div><!--<Nesting>--></svelte-retag></nesting-tag>';
-
 	test('nested (zero levels)', async () => {
 		el = document.createElement('div');
 		el.innerHTML = '<nesting-tag></nesting-tag>';
 		document.body.appendChild(el);
-		expect(normalizeWhitespace(el.innerHTML)).toBe(nestedOpen + nestedClose);
+
+		// Instead of doing direct HTML comparison, use DOM API to ensure the expected <div> is found nested under the parent.
+		const nestingTag = el.querySelector('nesting-tag');
+		const div = nestingTag.querySelector('div');
+		expect(div).not.toBe(null);
 	});
 	test('nested (one level)', async () => {
 		el = document.createElement('div');
 		el.innerHTML = '<nesting-tag><nesting-tag></nesting-tag></nesting-tag>';
 		document.body.appendChild(el);
-		expect(normalizeWhitespace(el.innerHTML)).toBe(nestedOpen + nestedOpen + nestedClose + nestedClose);
+
+		// Same as above, except we should ensure we can find the following hierarchy: nesting-tag > div > nesting-tag > div
+		// Also just verify each tag is present as we go down.
+		const topNestingTag = el.querySelector('nesting-tag');
+		expect(topNestingTag).not.toBe(null);
+		const topDiv = topNestingTag.querySelector('div');
+		expect(topDiv).not.toBe(null);
+		const nestedNestingTag = topDiv.querySelector('nesting-tag');
+		expect(nestedNestingTag).not.toBe(null);
+		const nestedDiv = nestedNestingTag.querySelector('div');
+		expect(nestedDiv).not.toBe(null);
 	});
 });

--- a/tests/Simple.light-dom-whitespace.test.js
+++ b/tests/Simple.light-dom-whitespace.test.js
@@ -24,20 +24,24 @@ describe('<simple-tag> (Light DOM)', () => {
 		window.requestAnimationFrame.mockRestore();
 	});
 
-	const unmodifiedOutput = '<simple-tag><svelte-retag>Initial 1 Initial Initial 2<!--<Simple>--></svelte-retag></simple-tag>';
+	const unmodifiedWrapperHTML = '<div>Initial 1 Initial Initial 2</div>';
+	function getWrapperHtml() {
+		return el.querySelector('div').outerHTML;
+	}
 
 	test('whitespace is ignored in unnamed default slot (single space)', async () => {
 		el = document.createElement('div');
 		el.innerHTML = '<simple-tag> </simple-tag>';
 		document.body.appendChild(el);
-		expect(el.innerHTML).toBe(unmodifiedOutput);
+
+		expect(getWrapperHtml()).toBe(unmodifiedWrapperHTML);
 	});
 
 	test('whitespace is ignored in unnamed default slot (mixed space 1)', async () => {
 		el = document.createElement('div');
 		el.innerHTML = '<simple-tag>\t \n \r</simple-tag>';
 		document.body.appendChild(el);
-		expect(el.innerHTML).toBe(unmodifiedOutput);
+		expect(getWrapperHtml()).toBe(unmodifiedWrapperHTML);
 	});
 
 	test('whitespace is ignored in unnamed default slot (mixed space 2)', async () => {
@@ -49,14 +53,14 @@ describe('<simple-tag> (Light DOM)', () => {
 			</simple-tag>
 `;
 		document.body.appendChild(el);
-		expect(el.innerHTML.trim()).toBe(unmodifiedOutput);
+		expect(getWrapperHtml()).toBe(unmodifiedWrapperHTML);
 	});
 
 	test('comments ignored in unnamed default slot', async () => {
 		el = document.createElement('div');
 		el.innerHTML = '<simple-tag><!-- comment --></simple-tag>';
 		document.body.appendChild(el);
-		expect(el.innerHTML).toBe(unmodifiedOutput);
+		expect(getWrapperHtml()).toBe(unmodifiedWrapperHTML);
 	});
 
 	test('comments mixed with whitespace ignored in unnamed default slot', async () => {
@@ -67,7 +71,7 @@ describe('<simple-tag> (Light DOM)', () => {
 			</simple-tag>
 `;
 		document.body.appendChild(el);
-		expect(el.innerHTML.trim()).toBe(unmodifiedOutput);
+		expect(getWrapperHtml()).toBe(unmodifiedWrapperHTML);
 	});
 
 	test('text nodes surrounding comments still gets slotted in unnamed default slot', async () => {
@@ -78,7 +82,7 @@ describe('<simple-tag> (Light DOM)', () => {
 			</simple-tag>
 `;
 		document.body.appendChild(el);
-		expect(normalizeWhitespace(el.innerHTML)).toBe('<simple-tag><svelte-retag>Initial 1 a <!-- comment --> b Initial 2<!--<Simple>--></svelte-retag></simple-tag>');
+		expect(normalizeWhitespace(getWrapperHtml())).toBe('<div>Initial 1 a <!-- comment --> b Initial 2</div>');
 	});
 
 });

--- a/tests/Simple.svelte
+++ b/tests/Simple.svelte
@@ -1,3 +1,5 @@
-<slot name="inner1">Initial 1</slot>
-<slot>Initial</slot>
-<slot name="inner2">Initial 2</slot>
+<div>
+	<slot name="inner1">Initial 1</slot>
+	<slot>Initial</slot>
+	<slot name="inner2">Initial 2</slot>
+</div>

--- a/tests/TestTag.light-dom.test.js
+++ b/tests/TestTag.light-dom.test.js
@@ -25,34 +25,36 @@ describe('<test-tag> (Light DOM)', () => {
 		window.requestAnimationFrame.mockRestore();
 	});
 
+	function getMainHtml() {
+		return el.querySelector('main').innerHTML;
+	}
+
 	test('without slots', async () => {
 		el = document.createElement('div');
 		el.innerHTML = '<test-tag></test-tag>';
 		document.body.appendChild(el);
-		expect(el.innerHTML).toBe('<test-tag><svelte-retag><h1>Main H1</h1> <div class="content">Main Default <div>Inner Default</div></div><!--<TestTag>--></svelte-retag></test-tag>');
+		expect(getMainHtml()).toBe('<h1>Main H1</h1> <div class="content">Main Default <div>Inner Default</div></div>');
 	});
 
 	test('with just default slot', () => {
 		el = document.createElement('div');
 		el.innerHTML = '<test-tag>BOOM!</test-tag>';
 		document.body.appendChild(el);
-		expect(el.innerHTML).toBe('<test-tag><svelte-retag><h1>Main H1</h1> <div class="content">BOOM! <div>Inner Default</div></div><!--<TestTag>--></svelte-retag></test-tag>');
+		expect(getMainHtml()).toBe('<h1>Main H1</h1> <div class="content">BOOM! <div>Inner Default</div></div>');
 	});
-
-	// TODO: Validate default (unnamed) slots that contain 1.) only whitespace, 2.) comments and whitespace or 3.) only text nodes
 
 	test('with just inner slot', () => {
 		el = document.createElement('div');
 		el.innerHTML = '<test-tag><div slot="inner">HERE</div></test-tag>';
 		document.body.appendChild(el);
-		expect(el.innerHTML).toBe('<test-tag><svelte-retag><h1>Main H1</h1> <div class="content">Main Default <div><div slot="inner">HERE</div></div></div><!--<TestTag>--></svelte-retag></test-tag>');
+		expect(getMainHtml()).toBe('<h1>Main H1</h1> <div class="content">Main Default <div><div slot="inner">HERE</div></div></div>');
 	});
 
 	test('both slots', () => {
 		el = document.createElement('div');
 		el.innerHTML = '<test-tag>BOOM!<div slot="inner">HERE</div></test-tag>';
 		document.body.appendChild(el);
-		expect(el.innerHTML).toBe('<test-tag><svelte-retag><h1>Main H1</h1> <div class="content">BOOM! <div><div slot="inner">HERE</div></div></div><!--<TestTag>--></svelte-retag></test-tag>');
+		expect(getMainHtml()).toBe('<h1>Main H1</h1> <div class="content">BOOM! <div><div slot="inner">HERE</div></div></div>');
 	});
 
 	// Unit test to validate that an error occurs when they define a "default" named slot but have remaining unslotted elements left over.
@@ -67,7 +69,7 @@ describe('<test-tag> (Light DOM)', () => {
 		el = document.createElement('div');
 		el.innerHTML = '<test-tag>Remaining content<div slot="default">Default already set</div></test-tag>';
 		document.body.appendChild(el);
-		expect(el.innerHTML).toBe('<test-tag><svelte-retag><h1>Main H1</h1> <div class="content"><div slot="default">Default already set</div> <div>Inner Default</div></div><!--<TestTag>--></svelte-retag></test-tag>');
+		expect(getMainHtml()).toBe('<h1>Main H1</h1> <div class="content"><div slot="default">Default already set</div> <div>Inner Default</div></div>');
 		expect(errors).toStrictEqual(['svelteRetag: \'TEST-TAG\': Found elements without slot attribute when using slot="default"']);
 
 		// Revert
@@ -78,7 +80,7 @@ describe('<test-tag> (Light DOM)', () => {
 		el = document.createElement('div');
 		el.innerHTML = '<test-tag><h2>Nested</h2><div slot="inner">HERE</div></test-tag>';
 		document.body.appendChild(el);
-		expect(el.innerHTML).toBe('<test-tag><svelte-retag><h1>Main H1</h1> <div class="content"><h2>Nested</h2> <div><div slot="inner">HERE</div></div></div><!--<TestTag>--></svelte-retag></test-tag>');
+		expect(getMainHtml()).toBe('<h1>Main H1</h1> <div class="content"><h2>Nested</h2> <div><div slot="inner">HERE</div></div></div>');
 	});
 
 	// Validate that nested slots are working as expected (same tag)
@@ -86,46 +88,30 @@ describe('<test-tag> (Light DOM)', () => {
 		const html = `
 			<test-tag>
 				<h1>TOP: DEFAULT</h1>
-				<div slot="inner">TOP: INNER NAMED SLOT</div>
+				<div id="level1" slot="inner">TOP: INNER NAMED SLOT</div>
 
 				<!-- Will be shifted above "inner" -->
 				<test-tag>
 					<h2>NESTED: DEFAULT</h2>
-					<div slot="inner">NESTED: INNER NAMED SLOT</div>
+					<div id="level2" slot="inner">NESTED: INNER NAMED SLOT</div>
 				</test-tag>
 
-			</test-tag>
-		`;
-		const expectRendered = `
-			<test-tag>
-				<svelte-retag>
-					<h1>Main H1</h1>
-					<div class="content">
-						<h1>TOP: DEFAULT</h1>
-
-						<!-- Will be shifted above "inner" -->
-						<test-tag>
-							<svelte-retag>
-								<h1>Main H1</h1>
-								<div class="content">
-									<h2>NESTED: DEFAULT</h2>
-									<div><div slot="inner">NESTED: INNER NAMED SLOT</div></div>
-								</div>
-								<!--<TestTag>-->
-							</svelte-retag>
-						</test-tag>
-
-						<div><div slot="inner">TOP: INNER NAMED SLOT</div></div>
-					</div>
-					<!--<TestTag>-->
-				</svelte-retag>
 			</test-tag>
 		`;
 
 		el = document.createElement('div');
 		el.innerHTML = html;
 		document.body.appendChild(el);
-		expect(normalizeWhitespace(el.innerHTML)).to.equal(normalizeWhitespace(expectRendered));
+
+
+		// To easily verify that the nested <test-tag> is hoisted into the default slot ABOVE the "inner" slot, we can simply
+		// fetch all the div[slot="inner"] elements and verify that the last one that appears is actually the "level1" div.
+		const innerDivs = el.querySelectorAll('div[slot="inner"]');
+		expect(innerDivs.length).toBe(2);
+		const lastInnerDiv = innerDivs[innerDivs.length - 1];
+
+		// Just verify last has the ID of the "level1" div.
+		expect(lastInnerDiv.id).toBe('level1');
 	});
 
 	// Validate that nested slots are working as expected even when rendered inside another custom element before that parent
@@ -135,59 +121,14 @@ describe('<test-tag> (Light DOM)', () => {
 		const html = `
 			<!-- Declared late -->
 			<outer-tag>
-				<h1>OUTER DEFAULT</h1>
+				<h2>OUTER DEFAULT</h2>
+				<div id="level1" slot="inner">OUTER INNER NAMED SLOT</div>
 
-				<!-- Declared already -->
+				<!-- Declared early -->
 				<test-tag>
-					<h2>INNER DEFAULT</h2>
+					<h3>INNER DEFAULT</h3>
+					<div id="level2" slot="inner">INNER INNER NAMED SLOT</div>
 				</test-tag>
-			</outer-tag>
-		`;
-
-		const expectBeforeOuterTag = `
-			<!-- Declared late -->
-			<outer-tag>
-				<h1>OUTER DEFAULT</h1>
-
-				<!-- Declared already -->
-				<test-tag>
-					<svelte-retag>
-						<h1>Main H1</h1>
-						<div class="content">
-							<h2>INNER DEFAULT</h2>
-							<div>Inner Default</div>
-						</div>
-						<!--<TestTag>-->
-					</svelte-retag>
-				</test-tag>
-
-			</outer-tag>
-		`;
-
-		const expectAfterOuterTag = `
-			<!-- Declared late -->
-			<outer-tag>
-				<svelte-retag>
-					<h1>Main H1</h1>
-					<div class="content">
-						<h1>OUTER DEFAULT</h1>
-
-						<!-- Declared already -->
-						<test-tag>
-							<svelte-retag>
-								<h1>Main H1</h1>
-								<div class="content">
-									<h2>INNER DEFAULT</h2>
-									<div>Inner Default</div>
-								</div>
-								<!--<TestTag>-->
-							</svelte-retag>
-						</test-tag>
-
-						<div>Inner Default</div>
-					</div>
-					<!--<TestTag>-->
-				</svelte-retag>
 			</outer-tag>
 		`;
 
@@ -196,24 +137,58 @@ describe('<test-tag> (Light DOM)', () => {
 		el.innerHTML = html;
 		document.body.appendChild(el);
 
-		// Validate that the outer tag isn't rendered yet.
-		expect(normalizeWhitespace(el.innerHTML)).to.equal(normalizeWhitespace(expectBeforeOuterTag));
+		// Validate that the outer tag isn't rendered yet. This can be easily verified by getting the getting div#level1 and
+		// ensuring its direct parent is <outer-tag> since it will not have been rendered yet (and nested more deeply).
+		const level1 = el.querySelector('#level1');
+		expect(level1.parentElement.tagName).toBe('OUTER-TAG');
+
+		// Validate expected slot contents for the inner <test-tag> element. Check that both the default slot contains an h3
+		// directly below the .content div and that the inner slot contains the div#level2 element.
+		function validateInnerTag() {
+			const innerTag = el.querySelector('test-tag');
+			const innerH3 = innerTag.querySelector('.content > h3');
+			expect(innerH3.textContent).toBe('INNER DEFAULT');
+			const innerSlot = innerTag.querySelector('div[slot="inner"]');
+			expect(innerSlot.id).toBe('level2');
+
+			// Ensure that the inner tag is below outer tag as expected (nested more deeply now that Svelte has rendered).
+			expect(innerTag.closest('outer-tag')).not.toBeNull();
+		}
+		validateInnerTag();
 
 		// Define the '<outer-tag>' late now even though
 		svelteRetag({ component: TestTag, tagname: 'outer-tag', shadow: false });
 
-		// Validate that the otuer tag has rendered AND that the inner tag is still intact.
-		expect(normalizeWhitespace(el.innerHTML)).to.equal(normalizeWhitespace(expectAfterOuterTag));
+		// Validate that the outer tag has rendered with all expected slot contents in a similar fashion as the inner tag.
+		const outerTag = el.querySelector('outer-tag');
+		const outerH2 = outerTag.querySelector('.content > h2');
+		expect(outerH2.textContent).toBe('OUTER DEFAULT');
+
+		// The inner slot with the ID of "level1" should actually be the last one since the default slot is above the inner slot.
+		const outerInnerSlot = outerTag.querySelectorAll('div[slot="inner"]');
+		expect(outerInnerSlot.length).toBe(2);
+		const lastOuterInnerSlot = outerInnerSlot[outerInnerSlot.length - 1];
+		expect(lastOuterInnerSlot.id).toBe('level1');
+
+		// Finally, double check that the inner tag is still present and in the expected position.
+		validateInnerTag();
 	});
 
 	test('unknown slot gets ignored', () => {
+		// temporarily override the console.warn function so we can validate later that it was called as expected with the expected warnings.
 		let tmp = console.warn;
-		console.warn = function() {
+		let warnings = [];
+		console.warn = function(message) {
+			warnings.push(message);
 		};
 		el = document.createElement('div');
 		el.innerHTML = '<test-tag><div slot="unknown">HERE</div></test-tag>';
 		document.body.appendChild(el);
-		expect(el.innerHTML).toBe('<test-tag><svelte-retag><h1>Main H1</h1> <div class="content">Main Default <div>Inner Default</div></div><!--<TestTag>--></svelte-retag></test-tag>');
+		expect(getMainHtml()).toBe('<h1>Main H1</h1> <div class="content">Main Default <div>Inner Default</div></div>');
 		console.warn = tmp;
+
+		// Validate that we got just 1 warning and that it contains 'received an unexpected slot "unknown"'.
+		expect(warnings.length).toBe(1);
+		expect(warnings[0]).toContain('received an unexpected slot "unknown"');
 	});
 });

--- a/tests/TestTag.light-dom.test.js
+++ b/tests/TestTag.light-dom.test.js
@@ -1,7 +1,7 @@
 import { describe, beforeAll, afterAll, afterEach, test, expect, vi } from 'vitest';
 import TestTag from './TestTag.svelte';
 import svelteRetag from '../index.js';
-import { normalizeWhitespace, syncRaf } from './test-utils.js';
+import { syncRaf } from './test-utils.js';
 
 // See vite.config.js for configuration details.
 

--- a/tests/TestTag.svelte
+++ b/tests/TestTag.svelte
@@ -1,7 +1,9 @@
-<h1>Main H1</h1>
-<div class="content">
-	<slot>Main Default</slot>
-	<div>
-		<slot name="inner">Inner Default</slot>
+<main>
+	<h1>Main H1</h1>
+	<div class="content">
+		<slot>Main Default</slot>
+		<div>
+			<slot name="inner">Inner Default</slot>
+		</div>
 	</div>
-</div>
+</main>


### PR DESCRIPTION
Use query selectors and etc to validate the results of tests instead of doing direct HTML comparisons. This is a little more intuitive and also an important gradual step in moving away from the `<svelte-retag>` wrapper (see #20).